### PR TITLE
Version 1.2.3 

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@photonic/app",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/src/components/ConsolidationModal.tsx
+++ b/packages/app/src/components/ConsolidationModal.tsx
@@ -84,7 +84,10 @@ async function consolidate() {
       utxos,
       funding,
       true,
-      async (script) => await updateFtBalances(new Set([script]))
+      async (script) => {
+        await updateFtBalances(new Set([script]));
+        await updateRxdBalances(wallet.value.address);
+      }
     );
     funding = result.funding;
   }

--- a/packages/app/src/electrum/worker/updateTxos.ts
+++ b/packages/app/src/electrum/worker/updateTxos.ts
@@ -152,6 +152,7 @@ export const buildUpdateTXOs =
         for (const [id, utxo] of confs) {
           await db.txo.update(id, {
             height: utxo.height || Infinity,
+            spent: 0,
             // date: newTxs[utxo.tx_hash].raw.time || undefined, // how to get date without fetching?
           });
         }


### PR DESCRIPTION
- Attempted fix for consolidation bug where RXD balance shows zero. 
- Update RXD balances when consolidating.
-  Set spent to false when updating confirmed UTXOs.